### PR TITLE
Add load function

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,16 @@ Docker repo to play with Golang and fire off some connections at end points.
 
 ```
   -interview
-        Boolean flag for running interview logic on target
+        Boolean flag for running interview logic on target URL
+  -loops int
+        Number of times you want to hit target URL with a GET request (default 5)
   -target string
         Target URL for load testing
 ```
 
 `-target` is required.
+
+`-loops` controls how many GET requests will be made against target URL (default 5).
 
 `-interview` is optional, as this repo first started as an interview take home test! It will apply the following logic to your target URL:
 
@@ -54,7 +58,9 @@ The image's `ENTRYPOINT` is `./load` which allows you to pass any go-load argume
 ❯ docker run --rm github.com/dailyherold/go-load:0.0.1
 Usage of ./load:
   -interview
-        Boolean flag for running interview logic on target
+        Boolean flag for running interview logic on target URL
+  -loops int
+        Number of times you want to hit target URL with a GET request (default 5)
   -target string
         Target URL for load testing
 ```

--- a/load.go
+++ b/load.go
@@ -35,18 +35,23 @@ func load(url string, interview bool) {
 	output := fmt.Sprintf("Load func, url=%s, interview=%t", url, interview)
 	fmt.Println(output)
 
-	//timeout := time.Duration(1 * time.Second)
 	delay := 1
-	client := http.Client{
-		Timeout: timeout(delay*4),
-	}
 
-	resp, err := client.Get(url)
+	for i := 1; i <= 3; i++ {
+		client := http.Client{
+			Timeout: timeout(delay),
+		}
 
-	if err != nil {
-		fmt.Println(err)
-	} else {
-		fmt.Println(resp)
+		fmt.Println("Timeout of ", delay)
+		resp, err := client.Get(url)
+
+		if err != nil {
+			fmt.Println(err)
+			// If error, increase timeout by factor of two
+			delay = delay * 2
+		} else {
+			fmt.Println(resp)
+		}
 	}
 }
 

--- a/load.go
+++ b/load.go
@@ -12,6 +12,7 @@ func main() {
 	// Parse flags
 	interview := flag.Bool("interview", false, "Boolean flag for running interview logic on target")
 	target := flag.String("target", "", "Target URL for load testing")
+	loops := flag.Int("loops", 5, "Number of times you want to hit target URL with a GET request")
 
 	flag.Parse()
 
@@ -28,16 +29,20 @@ func main() {
 		fmt.Println("You will apply interview logic to ", *target)
 	}
 
-	load(*target, *interview)
+	load(*target, *interview, *loops)
 }
 
-func load(url string, interview bool) {
+func load(url string, interview bool, loops int) {
 	output := fmt.Sprintf("Load func, url=%s, interview=%t", url, interview)
 	fmt.Println(output)
 
 	delay := 1
 
-	for i := 1; i <= 3; i++ {
+	if interview {
+		loops = 3
+	}
+
+	for i := 1; i <= loops; i++ {
 		client := http.Client{
 			Timeout: timeout(delay),
 		}

--- a/load.go
+++ b/load.go
@@ -35,11 +35,21 @@ func load(url string, interview bool) {
 	output := fmt.Sprintf("Load func, url=%s, interview=%t", url, interview)
 	fmt.Println(output)
 
-	timeout := time.Duration(1 * time.Second)
+	//timeout := time.Duration(1 * time.Second)
+	delay := 1
 	client := http.Client{
-		Timeout: timeout,
+		Timeout: timeout(delay*4),
 	}
+
 	resp, err := client.Get(url)
-	fmt.Println(resp)
-	fmt.Println(err)
+
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(resp)
+	}
+}
+
+func timeout(seconds int) time.Duration {
+	return time.Duration(seconds) * time.Second
 }

--- a/load.go
+++ b/load.go
@@ -3,7 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
+	"time"
 )
 
 func main() {
@@ -25,4 +27,19 @@ func main() {
 	if *interview {
 		fmt.Println("You will apply interview logic to ", *target)
 	}
+
+	load(*target, *interview)
+}
+
+func load(url string, interview bool) {
+	output := fmt.Sprintf("Load func, url=%s, interview=%t", url, interview)
+	fmt.Println(output)
+
+	timeout := time.Duration(1 * time.Second)
+	client := http.Client{
+		Timeout: timeout,
+	}
+	resp, err := client.Get(url)
+	fmt.Println(resp)
+	fmt.Println(err)
 }

--- a/load.go
+++ b/load.go
@@ -22,34 +22,37 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Println("URL target is ", *target)
-
 	// Notify user if interview logic is enabled
 	if *interview {
-		fmt.Println("You will apply interview logic to ", *target)
+		fmt.Println("Interview logic will be applied to ", *target)
 	}
 
 	load(*target, *interview, *loops)
 }
 
 func load(url string, interview bool, loops int) {
-	output := fmt.Sprintf("Load func, url=%s, interview=%t", url, interview)
-	fmt.Println(output)
-
+	var output string
 	delay := 1
 
+	// limit loops to 3 for interview logic to satisfy 1s, 2s, 4s GET request requirement
 	if interview {
 		loops = 3
 	}
 
 	for i := 1; i <= loops; i++ {
+		// Set http client timeout
 		client := http.Client{
 			Timeout: timeout(delay),
 		}
 
-		fmt.Println("Timeout of ", delay)
+		// Log details about request
+		output = fmt.Sprintf("target=%s, timeout=%ds, loop=%d, interview=%t", url, delay, i, interview)
+		fmt.Println(output)
+
+		// GET request
 		resp, err := client.Get(url)
 
+		// Log response
 		if err != nil {
 			fmt.Println(err)
 			// If error, increase timeout by factor of two

--- a/load.go
+++ b/load.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	// Parse flags
-	interview := flag.Bool("interview", false, "Boolean flag for running interview logic on target")
+	interview := flag.Bool("interview", false, "Boolean flag for running interview logic on target URL")
 	target := flag.String("target", "", "Target URL for load testing")
 	loops := flag.Int("loops", 5, "Number of times you want to hit target URL with a GET request")
 
@@ -22,11 +22,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Notify user if interview logic is enabled
-	if *interview {
-		fmt.Println("Interview logic will be applied to ", *target)
-	}
-
 	load(*target, *interview, *loops)
 }
 
@@ -34,7 +29,7 @@ func load(url string, interview bool, loops int) {
 	var output string
 	delay := 1
 
-	// limit loops to 3 for interview logic to satisfy 1s, 2s, 4s GET request requirement
+	// limit loops to 3 for interview logic to satisfy 1s, 2s, 4s GET request timeout requirement
 	if interview {
 		loops = 3
 	}


### PR DESCRIPTION
Use http client to fire off GET requests at `target` url. Send as many requests, sequentially, as there are `loops` defined, and if there are errors increase the timeout by factor of two for each subsequent request.

If `interview` logic, limit the loops to three, that way 1s, 2s, 4s GET request timeout requirement from interview is satisfied.